### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ let user = "user"
 let password = "password"
 
 let credentialData = "\(user):\(password)".dataUsingEncoding(NSUTF8StringEncoding)!
-let base64Credentials = credentialData.base64EncodedStringWithOptions(nil)
+let base64Credentials = credentialData.base64EncodedStringWithOptions(NSDataBase64EncodingOptions(rawValue:0))
 
 let headers = ["Authorization": "Basic \(base64Credentials)"]
 


### PR DESCRIPTION
In Xcode 7, the base64EncodedStringWithOptions method no longer compiles with a nil argument. The comments associated with that method suggest: "Use zero or one of the following...". This pull request updates the documentation to pass a NSDataBase64EncodingOptions value of 0 to this method. I would love to see something that doesn't involve using rawValue, but this seems to be the best option at this time.
